### PR TITLE
[fix] make kubernetesenv to comply with CRDs from 1.6

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
@@ -942,7 +942,7 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   compiledAdapter: kubernetesenv
-  params:
+  params: {}
     # when running from mixer root, use the following config after adding a
     # symbolic link to a kubernetes config file via:
     #


### PR DESCRIPTION
Make this CRD apply with istio 1.6 CRDs (the spec.params filed is not nullable)