### PR TITLE
Cinf 2165 remove depricated api 

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/autoscale.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/autoscale.yaml
@@ -21,6 +21,8 @@ spec:
   - type: Resource
     resource:
       name: cpu
-      targetAverageUtilization: {{ .Values.pilot.cpu.targetAverageUtilization }}
+      target: 
+          averageUtilization: {{ .Values.pilot.cpu.targetAverageUtilization }}
+          type: Utilization
 ---
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/poddisruptionbudget.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.defaultPodDisruptionBudget.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}


### PR DESCRIPTION
Update depreciated endpoints for k8s 1.25 update

this change is made outside of the public repo we forked.